### PR TITLE
feat: add input component password #48

### DIFF
--- a/app/View/Components/InputPassword.php
+++ b/app/View/Components/InputPassword.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class InputPassword extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.input-password');
+    }
+}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -18,28 +18,7 @@
                     </div>
                     <div class="card-body">
                         <x-input name="email" label="Email" required placeholder="Email Address...."></x-input>
-                        {{-- <x-input name="password" type="password" label="Password" required placeholder="Password...."></x-input> --}}
-                        <div x-data="{ showPassword: false }">
-                            <x-input name="password" x-bind:type="showPassword ? 'text' : 'password'" label="Password" required placeholder="Password...." icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                        <!-- Show when password is hidden -->
-                                        <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <!-- Show when password is visible -->
-                                        <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
+                        <x-input-password name="password" :validation="false" label="Password" placeholder="Password...." required></x-input-password>
 
                         <div class="flex flex-row justify-between mt-4">
                             <x-checkbox-input id="remember" name="remember">Remember</x-checkbox-input>

--- a/resources/views/auth/profile/index.blade.php
+++ b/resources/views/auth/profile/index.blade.php
@@ -43,86 +43,9 @@
                 @csrf
 
                 <div class="card-body">
-
-                    <div x-data="{ showPassword: false }">
-                        <x-input name="old_password" x-bind:type="showPassword ? 'text' : 'password'" label="Old Password" required placeholder="Old Password" icon>
-                            <x-slot name="iconContent">
-                                <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                    <!-- Show when password is hidden -->
-                                    <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                        <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                        <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                    </svg>
-                                    <!-- Show when password is visible -->
-                                    <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                        <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                        <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                        <path d="M3 3l18 18" />
-                                    </svg>
-                                </div>
-                            </x-slot>
-                        </x-input>
-                    </div>
-
-                    <div x-data="{ showPassword: false }">
-                        <x-input name="password" x-bind:type="showPassword ? 'text' : 'password'" label="Password" required placeholder="Password...." icon>
-                            <x-slot name="iconContent">
-                                <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                    <!-- Show when password is hidden -->
-                                    <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                        <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                        <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                    </svg>
-                                    <!-- Show when password is visible -->
-                                    <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                        <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                        <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                        <path d="M3 3l18 18" />
-                                    </svg>
-                                </div>
-                            </x-slot>
-                        </x-input>
-                    </div>
-
-                    <div x-data="{ showPassword: false }">
-                        <x-input name="password_confirmation" x-bind:type="showPassword ? 'text' : 'password'" label="Password Confirmation" required placeholder="Password Confirmation" icon>
-                            <x-slot name="iconContent">
-                                <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                    <!-- Show when password is hidden -->
-                                    <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                        <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                        <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                    </svg>
-                                    <!-- Show when password is visible -->
-                                    <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                        <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                        <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                        <path d="M3 3l18 18" />
-                                    </svg>
-                                </div>
-                            </x-slot>
-                        </x-input>
-                    </div>
-
-                    {{-- <div class="form-group">
-                        <label for="currentPassword">Current Password <span class="text-danger">*</span></label>
-                        <input type="password" id="currentPassword" name="currentPassword" placeholder="Current Password" />
-                    </div>
-                    <div class="form-group">
-                        <label for="newPassword">New Password <span class="text-danger">*</span></label>
-                        <input type="password" id="newPassword" name="newPassword" placeholder="New Password" />
-                    </div>
-                    <div class="form-group">
-                        <label for="confirmPassword">Confirm New Password
-                            <span class="text-danger">*</span></label>
-                        <input type="password" id="confirmPassword" name="confirmPassword" placeholder="Confirm New Password" />
-                    </div> --}}
+                    <x-input-password :validation="false" name="old_password" label="Old Password" placeholder="Old Password...." required></x-input-password>
+                    <x-input-password name="password" label="Password" placeholder="Password...." required></x-input-password>
+                    <x-input-password name="password_confirmation" label="Password Confirmation" placeholder="Password Confirmation...." required></x-input-password>
                 </div>
                 <div class="card-footer">
                     <button type="submit" class="button button-primary">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -20,45 +20,8 @@
                     <div class="card-body">
                         <x-input name="name" label="Name" placeholder="Name" required></x-input>
                         <x-input type="email" name="email" label="Email" placeholder="Email Address" required></x-input>
-                        <div x-data="{ showPassword: false }">
-                            <x-input name="password" x-bind:type="showPassword ? 'text' : 'password'" label="Password" placeholder="Password" required icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                        <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
-
-                        <div x-data="{ showConfirmPassword: false }">
-                            <x-input name="password_confirmation" x-bind:type="showConfirmPassword ? 'text' : 'password'" label="Password Confirmation" placeholder="Password Confirmation" required icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showConfirmPassword = !showConfirmPassword">
-                                        <svg x-show="!showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <svg x-show="showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
+                        <x-input-password name="password" label="Password" placeholder="Password...." required></x-input-password>
+                        <x-input-password name="password_confirmation" label="Password Confirmation" placeholder="Password Confirmation...." required></x-input-password>
 
                         <div class="flex flex-row justify-between mt-4">
                             <div></div>

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -18,45 +18,8 @@
                         </p>
                     </div>
                     <div class="card-body">
-                        <div x-data="{ showPassword: false }">
-                            <x-input type="password" name="password" x-bind:type="showPassword ? 'text' : 'password'" label="Password" placeholder="Password" icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                        <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
-
-                        <div x-data="{ showConfirmPassword: false }">
-                            <x-input name="password_confirmation" x-bind:type="showConfirmPassword ? 'text' : 'password'" label="Password Confirmation" placeholder="Password Confirmation" icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showConfirmPassword = !showConfirmPassword">
-                                        <svg x-show="!showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <svg x-show="showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
+                        <x-input-password name="password" label="Password" placeholder="Password...." required></x-input-password>
+                        <x-input-password name="password_confirmation" label="Password Confirmation" placeholder="Password Confirmation...." required></x-input-password>
                     </div>
 
                     <div class="card-footer">

--- a/resources/views/components/input-password.blade.php
+++ b/resources/views/components/input-password.blade.php
@@ -1,0 +1,82 @@
+@props([
+    'name' => 'password',
+    'label' => 'Password',
+    'placeholder' => 'Password....',
+    'required' => true,
+    'validation' => true,
+])
+
+<div x-data="{
+    showPassword: false,
+    password: '',
+    isValid: false,
+    validation: {{ $validation ? 'true' : 'false' }},
+    requirements: {
+        length: false,
+        uppercase: false,
+        lowercase: false,
+        number: false,
+        special: false
+    },
+    validatePassword() {
+        if (!this.validation) {
+            this.isValid = true;
+            return;
+        }
+
+        // Check each requirement separately
+        this.requirements.length = this.password.length >= 8;
+        this.requirements.uppercase = /[A-Z]/.test(this.password);
+        this.requirements.lowercase = /[a-z]/.test(this.password);
+        this.requirements.number = /\d/.test(this.password);
+        this.requirements.special = /[@$!%*?&]/.test(this.password);
+
+        // Overall validation
+        this.isValid = this.requirements.length &&
+            this.requirements.uppercase &&
+            this.requirements.lowercase &&
+            this.requirements.number &&
+            this.requirements.special;
+    }
+}">
+    <x-input name="{{ $name }}" x-bind:type="showPassword ? 'text' : 'password'" :label="$label" placeholder="{{ $placeholder }}" :required="$required" x-model="password" x-on:input="validatePassword()" x-bind:class="password && validation ? (isValid ? 'form-valid' : 'form-error') : ''" icon>
+        <x-slot name="iconContent">
+            <div class="cursor-pointer" @click="showPassword = !showPassword">
+                <!-- Show when password is hidden -->
+                <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                    <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+                    <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
+                </svg>
+                <!-- Show when password is visible -->
+                <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                    <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
+                    <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
+                    <path d="M3 3l18 18" />
+                </svg>
+            </div>
+        </x-slot>
+    </x-input>
+
+    <div x-show="password && validation" class="mt-2">
+        <p class="text-sm mb-1">Password requirements:</p>
+        <ul class="text-sm list-disc ml-5">
+            <li x-bind:class="requirements.length ? 'text-success dark:text-success-dark' : 'text-danger dark:text-danger-dark'">
+                At least 8 characters
+            </li>
+            <li x-bind:class="requirements.uppercase ? 'text-success dark:text-success-dark' : 'text-danger dark:text-danger-dark'">
+                At least one uppercase letter
+            </li>
+            <li x-bind:class="requirements.lowercase ? 'text-success dark:text-success-dark' : 'text-danger dark:text-danger-dark'">
+                At least one lowercase letter
+            </li>
+            <li x-bind:class="requirements.number ? 'text-success dark:text-success-dark' : 'text-danger dark:text-danger-dark'">
+                At least one number
+            </li>
+            <li x-bind:class="requirements.special ? 'text-success dark:text-success-dark' : 'text-danger dark:text-danger-dark'">
+                At least one special character (@$!%*?&)
+            </li>
+        </ul>
+    </div>
+</div>

--- a/resources/views/components/label.blade.php
+++ b/resources/views/components/label.blade.php
@@ -3,5 +3,5 @@
 @endphp
 
 <label for="{{ $attributes->get('for') }}" {{ $attributes->except(['for', 'required', 'class']) }} class="{{ $attributes->get('class') }} @error($attributes->get('name')) form-error @enderror">
-    {{ $label }} <span class="{{ $attributes->get('required') ? 'text-danger dark:text-danger-dark' : 'text-info dark:text-info-dark' }}">{{ $attributes->get('required') ? '*' : '' }}</span>
+    {{ $label }} <span class="{{ $attributes->get('required') ? 'text-danger dark:text-danger-dark' : 'text-info dark:text-info-dark' }}">{{ $attributes->get('required') ? '*' : '*' }}</span>
 </label>

--- a/resources/views/master/user/create.blade.php
+++ b/resources/views/master/user/create.blade.php
@@ -5,56 +5,14 @@
         <x-breadcrumb-item title="Create User" active></x-breadcrumb-item>
     </x-breadcrumb>
 
-    <x-card title="Create Role" class="mb-6">
+    <x-card title="Create Role" class="mb-6 w-full md:w-1/2">
         <form action="{{ route('master.user.store') }}" method="post">
             @csrf
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+            <div class="grid grid-cols-1 mb-6">
                 <x-input id="name" name="name" label="Name" placeholder="Name" type="text" required />
                 <x-input id="email" name="email" label="Email" placeholder="Email Address" type="text" required />
-
-                <div x-data="{ showPassword: false }">
-                    <x-input id="password" name="password" x-bind:type="showPassword ? 'text' : 'password'" label="Password" placeholder="Password" required icon>
-                        <x-slot name="iconContent">
-                            <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                <!-- Show when password is hidden -->
-                                <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                    <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                    <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                </svg>
-                                <!-- Show when password is visible -->
-                                <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                    <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                    <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                    <path d="M3 3l18 18" />
-                                </svg>
-                            </div>
-                        </x-slot>
-                    </x-input>
-                </div>
-
-                <div x-data="{ showConfirmPassword: false }">
-                    <x-input id="password_confirmation" name="password_confirmation" x-bind:type="showConfirmPassword ? 'text' : 'password'" label="Password Confirmation" placeholder="Password Confirmation" required icon>
-                        <x-slot name="iconContent">
-                            <div class="cursor-pointer" @click="showConfirmPassword = !showConfirmPassword">
-                                <!-- Show when password is hidden -->
-                                <svg x-show="!showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                    <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                    <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                </svg>
-                                <!-- Show when password is visible -->
-                                <svg x-show="showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                    <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                    <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                    <path d="M3 3l18 18" />
-                                </svg>
-                            </div>
-                        </x-slot>
-                    </x-input>
-                </div>
+                <x-input-password name="password" label="Password" placeholder="Password...." required></x-input-password>
+                <x-input-password name="password_confirmation" label="Password Confirmation" placeholder="Password Confirmation...." required></x-input-password>
 
                 <x-select id="select-2-role" name="role_id" label="Role" placeholder="Select Role">
 
@@ -71,6 +29,7 @@
                 $('#select-2-role').select2({
                     placeholder: 'Select Role',
                     allowClear: true,
+                    width: '100%',
                     ajax: {
                         url: '{{ route('select-option.role') }}', // Replace with your actual route for fetching roles
                         dataType: 'json',

--- a/resources/views/master/user/index.blade.php
+++ b/resources/views/master/user/index.blade.php
@@ -53,51 +53,8 @@
         <div class="p-5">
             <form id="update-password-form" method="POST" class="space-y-4">
                 @csrf
-
-                <div x-data="{ showPassword: false }">
-                    <x-input id="password" x-bind:type="showPassword ? 'text' : 'password'" label="New Password" name="password" required icon>
-                        <x-slot name="iconContent">
-                            <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                <!-- Show when password is hidden -->
-                                <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                    <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                    <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                </svg>
-                                <!-- Show when password is visible -->
-                                <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                    <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                    <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                    <path d="M3 3l18 18" />
-                                </svg>
-                            </div>
-                        </x-slot>
-                    </x-input>
-                </div>
-
-                <div x-data="{ showConfirmPassword: false }">
-                    <x-input id="password_confirmation" x-bind:type="showConfirmPassword ? 'text' : 'password'" label="Confirm Password" name="password_confirmation" required icon>
-                        <x-slot name="iconContent">
-                            <div class="cursor-pointer" @click="showConfirmPassword = !showConfirmPassword">
-                                <!-- Show when password is hidden -->
-                                <svg x-show="!showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                    <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                    <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                </svg>
-                                <!-- Show when password is visible -->
-                                <svg x-show="showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                    <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                    <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                    <path d="M3 3l18 18" />
-                                </svg>
-                            </div>
-                        </x-slot>
-                    </x-input>
-                </div>
-
+                <x-input-password name="password" label="Password" placeholder="Password...." required></x-input-password>
+                <x-input-password name="password_confirmation" label="Password Confirmation" placeholder="Password Confirmation...." required></x-input-password>
                 <div class="flex justify-end gap-3 mt-6">
                     <x-button type="button" @click="document.dispatchEvent(new CustomEvent('close-modal', { detail: 'update-password-modal' }))" class="button-secondary-soft">
                         Cancel

--- a/resources/views/pages/element/forms/input.blade.php
+++ b/resources/views/pages/element/forms/input.blade.php
@@ -27,14 +27,14 @@ name('element.forms.input');
 
         <div class="mb-6 space-y-4">
             <x-input name="username" label="Username" placeholder="Enter your username" class="form-input" />
-            <x-input name="password" type="password" label="Password" placeholder="Enter your password" class="form-input" />
+            <x-input-password name="password" label="Password" placeholder="Password...." required></x-input-password>
             <x-input name="email" type="email" label="Email" placeholder="Enter your email" required class="form-input" />
         </div>
 
         <div class="rounded-md">
             <pre class="max-h-[500px] overflow-auto"><code class="language-blade whitespace-pre">
 &lt;x-input name="username" label="Username" placeholder="Enter your username" class="form-input" /&gt;
-&lt;x-input name="password" type="password" label="Password" placeholder="Enter your password" class="form-input" /&gt;
+&lt;x-input-password name="password" label="Password" placeholder="Password...." required /&gt;
 &lt;x-input name="email" type="email" label="Email" placeholder="Enter your email" required class="form-input" /&gt;
             </code></pre>
         </div>
@@ -52,7 +52,7 @@ name('element.forms.input');
             <x-input name="text-example" type="text" label="Text Input" placeholder="Basic text input" class="form-input" />
             <x-input name="number-example" type="number" label="Number Input" class="form-input" />
             <x-input name="date-example" type="date" label="Date Input" class="form-input" />
-            <x-input name="password-example" type="password" label="Password Input" class="form-input" />
+            <x-input-password name="password" label="Password" placeholder="Password...." required></x-input-password>
             <x-input name="email-example" type="email" label="Email Input" class="form-input" />
         </div>
 
@@ -61,7 +61,7 @@ name('element.forms.input');
 &lt;x-input name="text-example" type="text" label="Text Input" placeholder="Basic text input" class="form-input" /&gt;
 &lt;x-input name="number-example" type="number" label="Number Input" class="form-input" /&gt;
 &lt;x-input name="date-example" type="date" label="Date Input" class="form-input" /&gt;
-&lt;x-input name="password-example" type="password" label="Password Input" class="form-input" /&gt;
+&lt;x-input-password name="password" label="Password" placeholder="Password...." required /&gt;
 &lt;x-input name="email-example" type="email" label="Email Input" class="form-input" /&gt;
             </code></pre>
         </div>

--- a/resources/views/pages/pages/login.blade.php
+++ b/resources/views/pages/pages/login.blade.php
@@ -23,28 +23,7 @@ name('pages.login');
                     </div>
                     <div class="card-body">
                         <x-input name="email" label="Email" required placeholder="Email Address...."></x-input>
-                        {{-- <x-input name="password" type="password" label="Password" required placeholder="Password...."></x-input> --}}
-                        <div x-data="{ showPassword: false }">
-                            <x-input name="password" x-bind:type="showPassword ? 'text' : 'password'" label="Password" required placeholder="Password...." icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                        <!-- Show when password is hidden -->
-                                        <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <!-- Show when password is visible -->
-                                        <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
+                        <x-input-password name="password" :validation="false" label="Password" placeholder="Password...." required></x-input-password>
 
                         <div class="flex flex-row justify-between mt-4">
                             <x-checkbox-input id="remember" name="remember">Remember</x-checkbox-input>

--- a/resources/views/pages/pages/register.blade.php
+++ b/resources/views/pages/pages/register.blade.php
@@ -25,45 +25,8 @@ name('pages.register');
                     <div class="card-body">
                         <x-input name="name" label="Name" placeholder="Name" required></x-input>
                         <x-input type="email" name="email" label="Email" placeholder="Email Address" required></x-input>
-                        <div x-data="{ showPassword: false }">
-                            <x-input name="password" x-bind:type="showPassword ? 'text' : 'password'" label="Password" placeholder="Password" required icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                        <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
-
-                        <div x-data="{ showConfirmPassword: false }">
-                            <x-input name="password_confirmation" x-bind:type="showConfirmPassword ? 'text' : 'password'" label="Password Confirmation" placeholder="Password Confirmation" required icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showConfirmPassword = !showConfirmPassword">
-                                        <svg x-show="!showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <svg x-show="showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
+                        <x-input-password name="password" label="Password" placeholder="Password...." required></x-input-password>
+                        <x-input-password name="password_confirmation" label="Password Confirmation" placeholder="Password Confirmation...." required></x-input-password>
 
                         <div class="flex flex-row justify-between mt-4">
                             <div></div>

--- a/resources/views/pages/pages/reset-password.blade.php
+++ b/resources/views/pages/pages/reset-password.blade.php
@@ -25,45 +25,8 @@ $token = request()->route('token') ?? Str::random(50);
                         </p>
                     </div>
                     <div class="card-body">
-                        <div x-data="{ showPassword: false }">
-                            <x-input type="password" name="password" x-bind:type="showPassword ? 'text' : 'password'" label="Password" placeholder="Password" icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showPassword = !showPassword">
-                                        <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
-
-                        <div x-data="{ showConfirmPassword: false }">
-                            <x-input name="password_confirmation" x-bind:type="showConfirmPassword ? 'text' : 'password'" label="Password Confirmation" placeholder="Password Confirmation" icon>
-                                <x-slot name="iconContent">
-                                    <div class="cursor-pointer" @click="showConfirmPassword = !showConfirmPassword">
-                                        <svg x-show="!showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-                                            <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
-                                        </svg>
-                                        <svg x-show="showConfirmPassword" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-eye-off">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                            <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-                                            <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
-                                            <path d="M3 3l18 18" />
-                                        </svg>
-                                    </div>
-                                </x-slot>
-                            </x-input>
-                        </div>
+                        <x-input-password name="password" label="Password" placeholder="Password...." required></x-input-password>
+                        <x-input-password name="password_confirmation" label="Password Confirmation" placeholder="Password Confirmation...." required></x-input-password>
                     </div>
 
                     <div class="card-footer">


### PR DESCRIPTION
This pull request introduces a reusable `InputPassword` component to simplify password input fields across the application. The changes replace inline password input implementations with this new component, improving code maintainability and consistency. Additionally, the `InputPassword` component includes built-in password validation with visual feedback for users.

### New `InputPassword` Component:
* Created a new `InputPassword` class in `app/View/Components/InputPassword.php` to encapsulate the logic for rendering the password input component. The component renders a Blade view (`resources/views/components/input-password.blade.php`). [[1]](diffhunk://#diff-02d6ff0534f59c4bdd0f575bfa73318eaeeb68cd823160e6655cfdf97e0ffd3cR1-R26) [[2]](diffhunk://#diff-f526c39e1546b599128e51bdd791d1e78ec30433c6b48e6ff906d40ae8c47919R1-R82)

### Password Input Refactoring:
* Replaced inline password input fields with the new `<x-input-password>` component in the following views:
  - `resources/views/auth/login.blade.php`
  - `resources/views/auth/profile/index.blade.php`
  - `resources/views/auth/register.blade.php`
  - `resources/views/auth/reset-password.blade.php`

### Features of the New Component:
* Provides a toggle to show/hide the password using Alpine.js.
* Includes password strength validation (optional) with the following requirements:
  - At least 8 characters.
  - At least one uppercase letter.
  - At least one lowercase letter.
  - At least one number.
  - At least one special character (@$!%*?&).